### PR TITLE
Revert "2.0.0 - Add not configured callback"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Configurations provides a unified approach to do configurations using the `MyGem
 
 or with Bundler
 
-`gem 'configurations', '~> 2.0.0.pre'`
+`gem 'configurations', '~> 1.4.0'`
 
 Configurations uses [Semver 2.0](http://semver.org/)
 
@@ -55,23 +55,6 @@ MyGem.configuration.class #=> 'oooh wow'
 MyGem.configuration.foo.bar.baz #=> 'fizz'
 ```
 
-Undefined properties on an arbitrary configuration will return `nil`
-
-```
-MyGem.configuration.not_set #=> nil
-```
-
-If you want to define the behaviour for not set properties yourself, use `not_configured`.
-
-```
-module MyGem
-  not_configured do |prop|
-	raise NoMethodError, "#{prop} must be configured"
-  end
-end
-```
-
-
 ### Second way: Restricted Configuration
 
 If you just want some properties to be configurable, consider this option
@@ -102,22 +85,6 @@ Gives you:
 ```
 MyGem.configuration.foo #=> 'FOO'
 MyGem.configuration.bar.baz #=> 'FIZZ'
-```
-
-Not configured properties on a restricted configuration will raise `NoMethodError`
-
-```
-MyGem.configuration.not_set #=> <#NoMethodError>
-```
-
-If you want to define the behaviour for not set properties yourself, use `not_configured`. This will only affect properties set to configurable. All not configurable properties will raise `NoMethodError`.
-
-```
-module MyGem
-  not_configured do |prop|
-	warn :not_configured, "Please configure #{prop} or live in danger"
-  end
-end
 ```
 
 ### Third way: Type Restricted Configuration
@@ -154,18 +121,18 @@ module MyGem
   include Configurations
   configurable :foo do |value|
 
-	# The return value is what gets assigned, unless it is nil,
-	# in which case the original value persists
-	#
-	value + ' ooooh my'
+    # The return value is what gets assigned, unless it is nil,
+    # in which case the original value persists
+    #
+    value + ' ooooh my'
   end
   configurable String, bar: :baz do |value|
 
-	# value is guaranteed to be a string at this point
-	#
-	unless %w(bi ba bu).include?(value)
-	  raise ArgumentError, 'baz needs to be one of bi, ba, bu'
-	end
+    # value is guaranteed to be a string at this point
+    #
+    unless %w(bi ba bu).include?(value)
+      raise ArgumentError, 'baz needs to be one of bi, ba, bu'
+    end
   end
 end
 ```
@@ -199,7 +166,7 @@ module MyGem
   include Configurations
   configurable :foo, :bar
   configuration_method :foobar do |arg|
-	foo + bar + arg
+    foo + bar + arg
   end
 end
 ```
@@ -226,7 +193,7 @@ MyGem.configuration.foobar('ARG') #=> 'FOOBARARG'
 module MyGem
   include Configurations
   configuration_defaults do |c|
-	c.foo.bar.baz = 'BAR'
+    c.foo.bar.baz = 'BAR'
   end
 end
 ```

--- a/lib/configurations.rb
+++ b/lib/configurations.rb
@@ -12,5 +12,5 @@ module Configurations
 
   # Version number of Configurations
   #
-  VERSION = '2.0.0.pre'
+  VERSION = '1.4.0'
 end

--- a/lib/configurations/configurable.rb
+++ b/lib/configurations/configurable.rb
@@ -28,13 +28,7 @@ module Configurations
           #
           def configure(&block)
             raise ArgumentError, 'can not configure without a block' unless block_given?
-            @configuration = #{base.name}::Configuration.new(
-                                                              defaults: @configuration_defaults,
-                                                              methods: @configuration_methods,
-                                                              configurable: @configurable,
-                                                              not_configured: @not_configured_callback,
-                                                              &block
-                                                            )
+            @configuration = #{self}::Configuration.new(@configuration_defaults, @configurable, &block)
           end
         end
       EOF
@@ -91,19 +85,11 @@ module Configurations
       #   end
       #
       def configuration_method(method, &block)
-        raise ArgumentError, "can not be both a configurable property and a configuration method" if configurable?(method)
-        @configuration_methods ||= {}
-        @configuration_methods.merge! method => block
-      end
+        raise ArgumentError, "#{method} can not be both a configurable property and a configuration method" if configurable?(method)
 
-      # not_configured defines the behaviour when a property has not been configured
-      # This can be useful for presence validations of certain properties
-      # or behaviour for undefined properties deviating from the original behaviour
-      # @param [Proc] block the block to evaluate
-      # @yield [Symbol] the property that has not been configured
-      #
-      def not_configured(&block)
-        @not_configured_callback = block
+        Configuration.class_eval do
+          define_method method, &block
+        end
       end
 
       private

--- a/test/configurations/test_configurable_with_blocks_configuration.rb
+++ b/test/configurations/test_configurable_with_blocks_configuration.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class TestStricterConfigurationWithBlock < Minitest::Test
 
-  module BlocksConfigurationTestModule
-    include Configurations
+  BlocksConfigurationTestModule = testmodule_for(Configurations)
+  BlocksConfigurationTestModule.module_eval do
     configurable :property1, :property2 do |value|
       value.to_s + 'oooh'
     end

--- a/test/configurations/test_configuration_methods.rb
+++ b/test/configurations/test_configuration_methods.rb
@@ -2,9 +2,8 @@ require 'test_helper'
 
 class TestConfigurationMethods < Minitest::Test
 
-  module ConfigurationMethodsClassModule
-    include Configurations
-
+  ConfigurationMethodsClassModule = testmodule_for(Configurations)
+  ConfigurationMethodsClassModule.module_eval do
     class MyClass
       attr_reader :props
       def initialize(*props)
@@ -28,24 +27,13 @@ class TestConfigurationMethods < Minitest::Test
     end
   end
 
-  module ConfigurationNoMethodsClassModule
-    include Configurations
-
-    configurable :property3
-  end
-
   def setup
     ConfigurationMethodsClassModule.configure do |c|
       c.property1 = :one
       c.property2 = :two
     end
 
-    ConfigurationNoMethodsClassModule.configure do |c|
-      c.property3 = :three
-    end
-
     @configuration = ConfigurationMethodsClassModule.configuration
-    @no_method_configuration = ConfigurationNoMethodsClassModule.configuration
   end
 
   def test_configuration_method
@@ -73,12 +61,6 @@ class TestConfigurationMethods < Minitest::Test
           MyClass.new(c.property2)
         end
       end
-    end
-  end
-
-  def test_configuration_methods_unaffected
-    assert_raises NoMethodError do
-      @no_method_configuration.method3('ARG')
     end
   end
 

--- a/test/configurations/test_stricter_configuration.rb
+++ b/test/configurations/test_stricter_configuration.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 class TestStricterConfiguration < Minitest::Test
-  module StrictConfigurationTestModule
-    include Configurations
 
+  StrictConfigurationTestModule = testmodule_for(Configurations)
+  StrictConfigurationTestModule.module_eval do
     configurable :property1, :property2
     configurable String, :property3
     configurable Symbol, property4: :property5, property6: [:property7, :property8]
@@ -11,16 +11,6 @@ class TestStricterConfiguration < Minitest::Test
     configurable Fixnum, property4: :property12
     configurable Array, property9: { property10: { property11: :property12 } }
     configurable Hash, property9: { property10: { property11: :property13 } }
-  end
-
-  module StrictConfigurationTestModuleDefaultsError
-    include Configurations
-
-    configurable :property1, :property2
-
-    not_configured do |prop|
-      raise StandardError, 'Problem here'
-    end
   end
 
   def setup
@@ -36,12 +26,8 @@ class TestStricterConfiguration < Minitest::Test
       c.property9.property10.property11.property12 = %w(here I am)
       c.property9.property10.property11.property13 = { hi: :bye }
     end
-    StrictConfigurationTestModuleDefaultsError.configure do |c|
-      c.property1 = 'BASIC3'
-    end
 
     @configuration = StrictConfigurationTestModule.configuration
-    @configuration_defaults_error = StrictConfigurationTestModuleDefaultsError.configuration
   end
 
   def test_configurable_when_set_configurable
@@ -79,17 +65,17 @@ class TestStricterConfiguration < Minitest::Test
                      property7: :anything,
                      property8: :everything,
                      property14: 555
-                   },
+                   }, 
                    property9: {
                      property10: {
                        property11: {
-                         property12: %w(here I am),
+                         property12: %w(here I am), 
                          property13: {
                            hi: :bye
                          }
                        }
                      }
-                   },
+                   }, 
                    property1: 'BASIC1',
                    property2: 'BASIC2',
                    property3: 'STRING'
@@ -138,24 +124,10 @@ class TestStricterConfiguration < Minitest::Test
     end
   end
 
-  def test_respond_to_with_undefined_property
-    assert_equal false, @configuration.respond_to?(:property12)
-  end
-
   def test_not_callable_with_undefined_property
     assert_raises NoMethodError do
       @configuration.property12
     end
-  end
-
-  def test_not_configured_callback
-    assert_raises StandardError do
-      @configuration_defaults_error.property2
-    end
-  end
-
-  def test_not_configured_callback_not_triggered_for_configured
-    assert_equal 'BASIC3', @configuration_defaults_error.property1
   end
 
   def test_not_configurable_with_undefined_nested_property
@@ -166,8 +138,10 @@ class TestStricterConfiguration < Minitest::Test
     end
   end
 
-  def test_callable_with_undefined_nested_property
-    assert_nil @configuration.property6.property9
+  def test_not_callable_with_undefined_nested_property
+    assert_raises NoMethodError do
+      @configuration.property6.property9
+    end
   end
 
 end


### PR DESCRIPTION
Reverts beatrichartz/configurations#5 for now - `not_configured` callback should have an option to configure it for certain properties only.
