### PR TITLE
Configure with Hashes with string keys

### DIFF
--- a/lib/configurations/configuration.rb
+++ b/lib/configurations/configuration.rb
@@ -76,7 +76,7 @@ module Configurations
     #
     def from_h(h)
       h.each do |property, value|
-        if value.is_a?(::Hash) && __nested?(property)
+        if value.is_a?(::Hash) && __nested?(property.to_sym)
           @data[property.to_sym].from_h(value)
         elsif __configurable?(property)
           __assign!(property.to_sym, value)

--- a/lib/configurations/configuration.rb
+++ b/lib/configurations/configuration.rb
@@ -77,9 +77,9 @@ module Configurations
     def from_h(h)
       h.each do |property, value|
         if value.is_a?(::Hash) && __nested?(property)
-          @data[property].from_h(value)
+          @data[property.to_sym].from_h(value)
         elsif __configurable?(property)
-          __assign!(property, value)
+          __assign!(property.to_sym, value)
         end
       end
 


### PR DESCRIPTION
Grant the possibility to configure with Hashes with string keys by explicitly transforming every key to a symbol.