### PR TITLE
Enable warnings during test suite execution and fix most of them

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,5 @@ task default: :test
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.pattern = 'test/**/test*.rb'
+  t.warning = true
 end

--- a/lib/configurations/arbitrary.rb
+++ b/lib/configurations/arbitrary.rb
@@ -71,7 +71,7 @@ module Configurations
     #
     def __writeable__=(data)
       @writeable = data
-      return if @data.nil?
+      return unless defined?(@data) && @data
 
       @data.each do |_k, v|
         v.__writeable__ = data if v.is_a?(__class__)

--- a/lib/configurations/configurable.rb
+++ b/lib/configurations/configurable.rb
@@ -140,7 +140,8 @@ module Configurations
       # @return [Boolean] whether the property is configurable
       #
       def configurable?(property)
-        @configurable_properties != nil &&
+        defined?(@configurable_properties) &&
+          @configurable_properties &&
           @configurable_properties.configurable?(Path.new([property]))
       end
 
@@ -224,13 +225,19 @@ module Configurations
       #
       def configuration_options
         {
-          defaults: @configuration_defaults,
-          properties: @configurable_properties,
-          types: @configurable_types,
-          blocks: @configurable_blocks,
-          method_blocks: @configuration_method_blocks,
-          not_configured_blocks: @not_configured_blocks
-        }.delete_if { |_, value| value.nil? }
+          defaults:
+            defined?(@configuration_defaults) && @configuration_defaults,
+          properties:
+            defined?(@configurable_properties) && @configurable_properties,
+          types:
+            defined?(@configurable_types) && @configurable_types,
+          blocks:
+            defined?(@configurable_blocks) && @configurable_blocks,
+          method_blocks:
+            defined?(@configuration_method_blocks) && @configuration_method_blocks,
+          not_configured_blocks:
+            defined?(@not_configured_blocks) && @not_configured_blocks,
+        }.keep_if { |_, value| value }
       end
     end
   end

--- a/lib/configurations/configurable.rb
+++ b/lib/configurations/configurable.rb
@@ -214,10 +214,10 @@ module Configurations
       # @return the class name of the configuration class to use
       #
       def configuration_type
-        if @configurable_properties.nil? || @configurable_properties.empty?
-          Configurations::Arbitrary
-        else
+        if defined?(@configurable_properties) && @configurable_properties && !@configurable_properties.empty?
           Configurations::Strict
+        else
+          Configurations::Arbitrary
         end
       end
 

--- a/lib/configurations/configuration.rb
+++ b/lib/configurations/configuration.rb
@@ -104,7 +104,7 @@ module Configurations
     # @return [Boolean] whether the given property is configurable
     #
     def __configurable?(property)
-      if @configurable_properties
+      if defined?(@configurable_properties) && @configurable_properties
         @configurable_properties.configurable?(@path.add(property))
       else
         true
@@ -146,7 +146,7 @@ module Configurations
       hash = {}
       hash[:path] = nested_path
       hash[:data] = @data_map
-      hash[:properties] = @properties
+      hash[:properties] = defined?(@properties) && @properties
 
       hash[:not_configured_blocks] = @not_configured_blocks
 

--- a/lib/configurations/maps/blocks.rb
+++ b/lib/configurations/maps/blocks.rb
@@ -17,6 +17,7 @@ module Configurations
       def initialize(reader = Readers::Tolerant.new)
         @map = {}
         @reader = reader
+        @default = nil
       end
 
       def add_default(block)

--- a/lib/configurations/strict.rb
+++ b/lib/configurations/strict.rb
@@ -47,7 +47,7 @@ module Configurations
     # Get an options hash for a property
     #
     def __options_hash_for__(property)
-      nested_path = @path.add(property)
+      _nested_path = @path.add(property)
       super(property).merge(
         properties: @properties,
         types: @types,

--- a/test/configurations/configuration/test_configure_synchronized.rb
+++ b/test/configurations/configuration/test_configure_synchronized.rb
@@ -40,7 +40,7 @@ class TestConfigurationSynchronized < MiniTest::Test
       @@semaphore = Mutex.new
       def now
         @@semaphore.synchronize do
-          ("0.3f" % Time.now.to_f).to_f
+          ("%0.3f" % Time.now.to_f).to_f
         end
       end
     end

--- a/test/configurations/shared/hash_methods.rb
+++ b/test/configurations/shared/hash_methods.rb
@@ -49,9 +49,9 @@ module Tests
       end
 
       def test_from_h_with_unambiguous_strings_and_symbols
-        c = @module.configure { |c| c.from_h('p1' => 'bla', :p2 => 2) }
-        assert_equal 2, c.p2
-        assert_equal 'bla', c.p1
+        config = @module.configure { |c| c.from_h('p1' => 'bla', :p2 => 2) }
+        assert_equal 2, config.p2
+        assert_equal 'bla', config.p1
       end
     end
   end


### PR DESCRIPTION
One of the projects I am involved with makes use of the configurations gem (thanks so much for your work, btw!) and we recently turned on the rspec option to run our specs with warnings, which helped us fix a lot of warnings, but also got us a lot of warnings from gems we use.

So I'm now embarking on a quest to solve as many warnings as I can, so we can get clean specs again :)

I was able to fix most of the warnings I got when running the `configurations` specs, and I hope my approach is acceptable. I also found a bug in the `test_configure_synchronized.rb` spec that was resulting in a warning.

Thanks for your consideration!